### PR TITLE
fix responsive on Admin page

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -138,7 +138,7 @@ a .CV-link:focus,
 
 }
 .tab-container .tabs .tab.active {
-  background-color: var(--lightcolor);
+  background-color: gray !important;
   color: var(--darkcolor);
   cursor: auto;
 }

--- a/src/Templates/admin/index.twig
+++ b/src/Templates/admin/index.twig
@@ -4,71 +4,71 @@
 
 {% block body %}
 
-    {% set role = null %}
-    {% if user.role is same as "admin" %}
-        {% set role = "admin" %}
-    {% else %}
-        {% set role = "utilisateur" %}
-    {% endif %}
+{% set role = null %}
+{% if user.role is same as "admin" %}
+{% set role = "admin" %}
+{% else %}
+{% set role = "utilisateur" %}
+{% endif %}
 
-    <header class="py-5 bg-image-full" style="background-image: url('{{ ROOT }}images/background/blackwaves.jpg')">
-        <div class="text-center my-5">
-            <img class="img-fluid rounded-circle mb-4 separation " src="{{ ROOT }}images/deco/lineface.png" alt="..." />
-            {% if user.role is same as "admin" %}
-                <h1 class="text-white  fw-bolder">Page d'administration</h1>
-            {% else %}
-                <h1 class="text-white  fw-bolder">Mon compte</h1>
-            {% endif %}
-        </div>
-    </header>
-
-    {% if user.role is same as "admin" %}
-    {# general container of the admin part + aside #}
-    <div class="container p-0">
-
-        <div class="row">
-            {# General container of the Item Category Sub-Menus tabulation system #}
-            <section class="my-5 tab-container">
-
-                {# Button Container #}
-                <div class="tabs">
-                    {# Button 1 (displayed by default with active class) #}
-                    <div class="tab active" data-open="view1">
-                        <h3>Mes informations</h3>
-                    </div>
-                    {# Button 2 #}
-                    <div class="tab " data-open="view2">
-                        <h3>Ajouter un article</h3>
-                    </div>
-                    {# Button 3 #}
-                    <div class="tab " data-open="view3">
-                        <h3>Gestion des utilisateurs</h3>
-                    </div>
-                </div>
-
-                {# Container of views corresponding to buttons #}
-                <div class="views">
-                    {# View 1 - My information (displayed by default with the active class) #}
-                    <div class="view active" id="view1">
-                        {% include 'admin/partial/userPage.twig' %}
-                    </div>{# End view 1 #}
-
-                    {# View 2 - Add item #}
-                    <div class="view" id="view2">
-                        {% include 'admin/partial/createPost.twig' %}
-                    </div>{# End view 2 #}
-
-                    {# View 3 - Users #}
-                    <div class="view " id="view3">
-                        {% include 'admin/partial/manageUser.twig' %}
-                    </div> {# End view 3 #}
-                </div>
-
-            </section>
-        </div>
+<header class="py-5 bg-image-full" style="background-image: url('{{ ROOT }}images/background/blackwaves.jpg')">
+    <div class="text-center my-5">
+        <img class="img-fluid rounded-circle mb-4 separation " src="{{ ROOT }}images/deco/lineface.png" alt="..." />
+        {% if user.role is same as "admin" %}
+        <h1 class="text-white  fw-bolder">Page d'administration</h1>
+        {% else %}
+        <h1 class="text-white  fw-bolder">Mon compte</h1>
+        {% endif %}
     </div>
-    {% else %}
-        {% include 'admin/partial/userPage.twig' %}
-    {% endif %}
+</header>
+
+{% if user.role is same as "admin" %}
+{# general container of the admin part + aside #}
+<div class="container p-0">
+
+    <div class="row">
+        {# General container of the Item Category Sub-Menus tabulation system #}
+        <section class="my-5 tab-container">
+
+            {# Button Container #}
+            <div class="tabs col-12 d-flex flex-column flex-md-row">
+                {# Button 1 (displayed by default with active class) #}
+                <div class="tab border d-flex align-items-center bg-dark text-white col-md-4 active" data-open="view1">
+                    <h3 class="text-center mx-auto">Mes informations</h3>
+                </div>
+                {# Button 2 #}
+                <div class="tab border d-flex align-items-center bg-dark text-white col-md-4 " data-open="view2">
+                    <h3 class="text-center mx-auto">Nouvel article</h3>
+                </div>
+                {# Button 3 #}
+                <div class="tab border d-flex align-items-center bg-dark text-white col-md-4 " data-open="view3">
+                    <h3 class="text-center mx-auto">Gestion des utilisateurs</h3>
+                </div>
+            </div>
+
+            {# Container of views corresponding to buttons #}
+            <div class="views">
+                {# View 1 - My information (displayed by default with the active class) #}
+                <div class="view active" id="view1">
+                    {% include 'admin/partial/userPage.twig' %}
+                </div>{# End view 1 #}
+
+                {# View 2 - Add item #}
+                <div class="view" id="view2">
+                    {% include 'admin/partial/createPost.twig' %}
+                </div>{# End view 2 #}
+
+                {# View 3 - Users #}
+                <div class="view " id="view3">
+                    {% include 'admin/partial/manageUser.twig' %}
+                </div> {# End view 3 #}
+            </div>
+
+        </section>
+    </div>
+</div>
+{% else %}
+{% include 'admin/partial/userPage.twig' %}
+{% endif %}
 
 {% endblock body %}

--- a/src/Templates/admin/partial/manageUser.twig
+++ b/src/Templates/admin/partial/manageUser.twig
@@ -8,7 +8,7 @@
                     {% for user in users %}
                     <div>
                         <ul class="list-group my-3">
-                            <li class="list-group-item pe-0 d-flex justify-content-around shadow">
+                            <li class="list-group-item pe-0 d-flex flex-column justify-content-around shadow">
                                 <div class="card mb-3 col-10" style="max-width: 540px;">
                                     <div class="row g-0 p-2">
                                         <div class="col-md-4 mx-auto my-auto">
@@ -41,35 +41,39 @@
                                 </div>
 
                                 {% if session.logUser is same as 'admin' and user.role is not same as 'admin' %}
-                                <div class="d-flex justify-content-end align-items-end col-2">
-                                    <div class="p-1 ">
-                                        {% if user.is_verified is same as '1' %}
-                                        <form method="POST" action="admin/disableUser">
-                                            <input name="userId" type="hidden" value={{ user.id }}>
-                                            <input name="is_verified" type="hidden" value="0">
-                                            <button type="submit" class="btn" title="Désactiver le compte utlisateur">
-                                                <i class="fas fa-regular fa-square-check alert-danger"></i>
-                                            </button>
-                                        </form>
-                                        {% else %}
-                                        <form method="POST" action="admin/disableUser">
-                                            <input name="userId" type="hidden" value={{ user.id }}>
-                                            <input name="is_verified" type="hidden" value="1">
-                                            <button type="submit" class="btn" title="Désactiver le compte utlisateur">
-                                                <i class="fas fa-regular fa-square-check alert-info"></i>
-                                            </button>
-                                        </form>
-                                        {% endif %}
-                                    </div>
-                                    <div class="p-1 ">
-                                        <form method="POST" action="admin/deleteUser">
-                                            <input name="userId" type="hidden" value={{ user.id }}>
-                                            <button type="submit" class="btn"
-                                                onclick="return confirm('Êtes-vous sûr de vouloir supprimer cet utlisateur ?')"
-                                                title="Supprimer l'utlisateur">
-                                                <i class="fas fa-trash"></i>
-                                            </button>
-                                        </form>
+                                <div class="d-flex justify-content-end align-items-end">
+                                    <div class="d-flex flex-row ">
+                                        <div class="p-1 ">
+                                            {% if user.is_verified is same as '1' %}
+                                            <form method="POST" action="admin/disableUser">
+                                                <input name="userId" type="hidden" value={{ user.id }}>
+                                                <input name="is_verified" type="hidden" value="0">
+                                                <button type="submit" class="btn"
+                                                    title="Désactiver le compte utlisateur">
+                                                    <i class="fas fa-regular fa-square-check alert-danger"></i>
+                                                </button>
+                                            </form>
+                                            {% else %}
+                                            <form method="POST" action="admin/disableUser">
+                                                <input name="userId" type="hidden" value={{ user.id }}>
+                                                <input name="is_verified" type="hidden" value="1">
+                                                <button type="submit" class="btn"
+                                                    title="Désactiver le compte utlisateur">
+                                                    <i class="fas fa-regular fa-square-check alert-info"></i>
+                                                </button>
+                                            </form>
+                                            {% endif %}
+                                        </div>
+                                        <div class="p-1 ">
+                                            <form method="POST" action="admin/deleteUser">
+                                                <input name="userId" type="hidden" value={{ user.id }}>
+                                                <button type="submit" class="btn"
+                                                    onclick="return confirm('Êtes-vous sûr de vouloir supprimer cet utlisateur ?')"
+                                                    title="Supprimer l'utlisateur">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
                                     </div>
                                 </div>
                                 {% else %}


### PR DESCRIPTION
### Nouveaux comportements

Sous-menu page d'administration
- le sous-menu de la page d'administration reste dans le conteneur principal
- les tabulations ont des tailles identiques
- refactorisation du style des tabulations : background différent si active

Page de gestion des utilisateurs
- les deux icones de modérations sont visibles en format téléphone 
- ces deux icones sont à droite, afin de faciliter l'utilisation sur téléphone

### Autres informations

<!--
### Contexte

Utiliser ou créer l'un des labels suivants pour spécifier le périmètre et le type de la Pull Request :
- "type: bugfix", "type: feature", "type: poc"


-->
## _____________ ENGLISH ___________________
### New behaviors

Administration page sub-menu
- admin page submenu stays in main container
- the tabs have identical sizes
- tab style refactoring: different background if active

User management page
- the two moderation icons are visible in phone format
- these two icons are on the right, to facilitate use on the phone

### Other information

<!--
### Context

Use or create one of the following labels to specify the scope and type of the Pull Request:
- "type: bugfix", "type: feature", "type: poc"


-->